### PR TITLE
improve hpda engine by `status_end`

### DIFF
--- a/hpda/src/engine/engine.cpp
+++ b/hpda/src/engine/engine.cpp
@@ -5,9 +5,10 @@
 #include <unordered_map>
 #include <unordered_set>
 
-constexpr static uint32_t status_n = 0;
+constexpr static uint32_t status_null = 0;
 constexpr static uint32_t status_to_p = 1;
 constexpr static uint32_t status_p = 2;
+constexpr static uint32_t status_end = 3;
 
 namespace hpda {
 
@@ -43,74 +44,63 @@ void engine::run() {
     to_process.push(output);
   }
 
-  int i = 0;
   while (!to_process.empty()) {
+    // 1. BFS
     do {
       auto f = to_process.front();
       to_process.pop();
       if (f->predecessors().empty()) {
-        f->m_status = status_n;
         // it's an extractor
-        bool v = f->process();
-        if (v) {
+        if (f->process()) {
           f->done_value();
+          f->m_status = status_null;
         } else {
-          m_reach_ends.insert(f);
+          f->m_status = status_end; // extractor.process return false <=> end status
         }
       } else {
         f->m_status = status_p;
         processing.push(f);
       }
       for (auto input : f->predecessors()) {
-        if (!input->has_value() && input->m_status != status_to_p) {
+        if (!input->has_value() && \
+            input->m_status != status_to_p && \
+            input->m_status != status_end) {
           to_process.push(input);
           input->m_status = status_to_p;
         }
       }
-
-      // if (!to_process.empty() && !processing.empty()) {
-      // if (!contain_same_successor(to_process.front(), f, processing.top())) {
-      // break;
-      //}
-      //}
     } while (!to_process.empty());
-
+    // 2. pop stack
     while (!processing.empty()) {
       auto f = processing.top();
 
-      if (!functor_has_input(f)) {
-        break;
-      }
-
-      bool v = f->process();
-      if (v) {
+      if (f->process()) {
         f->done_value();
+        processing.pop();
+        f->m_status = status_null;
       } else {
         f->reset_done_value();
-      }
-      if (f->has_value()) {
-        processing.pop();
-        f->m_status = status_n;
-      } else {
         bool end = true;
         for (auto input : f->predecessors()) {
-          if (m_reach_ends.find(input) == m_reach_ends.end() &&
-              !(input->has_value())) {
+          if (!input->has_value() && \
+              input->m_status != status_end && \
+              input->m_status != status_to_p) {
             to_process.push(input);
             input->m_status = status_to_p;
             end = false;
           }
         }
-        if (end) {
-          m_reach_ends.insert(f);
-          processing.pop();
-          f->m_status = status_n;
+        if (!end) {
+          break;
         }
+        processing.pop();
+        f->m_status = status_end;
       }
     }
+    // 3. prepare BFS
     if (to_process.empty()) {
       for (auto output : outputs) {
-        if (m_reach_ends.find(output) == m_reach_ends.end()) {
+        if (output->m_status != status_end && output->m_status != status_to_p) {
           to_process.push(output);
           output->m_status = status_to_p;
         }
@@ -123,7 +113,6 @@ void engine::run() {
 void engine::build_graph() {
   m_predecessors.clear();
   m_successors.clear();
-  m_reach_ends.clear();
   for (auto f : m_functors) {
     if (m_predecessors.find(f) == m_predecessors.end()) {
       m_predecessors.insert(std::make_pair(f, std::unordered_set<functor *>()));
@@ -139,7 +128,7 @@ void engine::build_graph() {
       m_successors[input].insert(f);
       m_predecessors[f].insert(input);
     }
-    f->m_status = status_n;
+    f->m_status = status_null;
   }
 }
 std::vector<functor *> engine::find_outputs() const {
@@ -160,18 +149,6 @@ bool engine::contain_same_successor(functor *f1, functor *f2,
     return true;
   }
   return false;
-}
-
-bool engine::functor_has_input(functor *f) const {
-  const std::vector<functor *> &inputs = f->predecessors();
-  bool ret = true;
-  for (auto input : inputs) {
-    if (m_reach_ends.find(input) != m_reach_ends.end()) {
-      continue;
-    }
-    ret = ret && input->has_value();
-  }
-  return ret;
 }
 
 bool engine::is_output(functor *f) const {


### PR DESCRIPTION
Marking the processors that no longer generate outputs as `status_end` reduces the scheduling overhead.